### PR TITLE
トップフォルダの.gitignoreを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-**/.devcontainer/
-**/node_modules/
 **/.DS_Store


### PR DESCRIPTION
## 対応内容

* #35 
* `.devcontainer`などの共有のため、トップフォルダで一律でフォルダを無視する設定を削除
* プロジェクトごとに都度設定する
* `.DS_Storre`は不要

## 依頼事項

## 関連リンク

## その他

Closes #35 